### PR TITLE
fix: hotfix builds no longer marked as latest release

### DIFF
--- a/.github/workflows/auto-hotfix.yml
+++ b/.github/workflows/auto-hotfix.yml
@@ -78,6 +78,8 @@ jobs:
           body: |
             Automatic hotfix release.
             **Commits since last release:** ${{ steps.commitcount.outputs.count }}
-
+          draft: false
+          prerelease: true
+          make_latest: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updates auto-hotfix.yml to no longer mark it as latest release when built.